### PR TITLE
JWT AccessToken 인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,11 @@ dependencies {
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+    //JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     //VALIDATION
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/src/main/java/com/example/bloombackend/global/config/JwtTokenProvider.java
+++ b/src/main/java/com/example/bloombackend/global/config/JwtTokenProvider.java
@@ -36,13 +36,15 @@ public class JwtTokenProvider {
         return Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public String getUserIdFromToken(String token) {
-        return Jwts.parserBuilder()
+    public Long getUserIdFromToken(String token) {
+        return Long.parseLong(
+                Jwts.parserBuilder()
                 .setSigningKey(getSecretKey())
                 .build()
                 .parseClaimsJws(token)
                 .getBody()
-                .getSubject();
+                .getSubject()
+        );
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/com/example/bloombackend/global/config/JwtTokenProvider.java
+++ b/src/main/java/com/example/bloombackend/global/config/JwtTokenProvider.java
@@ -1,0 +1,56 @@
+package com.example.bloombackend.global.config;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+    @Value("${jwt.secret_key}")
+    private String encodedSecretKey;
+
+    @Value("${jwt.access_token.valid_time}")
+    private Long accessTokenValidTime;
+
+    public String createAccessToken(String userId) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + accessTokenValidTime);
+
+        return Jwts.builder()
+                .setSubject(userId)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(getSecretKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private Key getSecretKey() {
+        byte[] keyBytes = Base64.getDecoder().decode(encodedSecretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String getUserIdFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSecretKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(getSecretKey()).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/example/bloombackend/global/config/WebConfig.java
+++ b/src/main/java/com/example/bloombackend/global/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.example.bloombackend.global.config;
+
+import com.example.bloombackend.global.config.resolver.CurrentUserResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final CurrentUserResolver currentUserResolver;
+
+    public WebConfig(final CurrentUserResolver currentUserResolver) {
+        this.currentUserResolver = currentUserResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(currentUserResolver);
+    }
+}

--- a/src/main/java/com/example/bloombackend/global/config/annotation/CurrentUser.java
+++ b/src/main/java/com/example/bloombackend/global/config/annotation/CurrentUser.java
@@ -1,0 +1,11 @@
+package com.example.bloombackend.global.config.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/src/main/java/com/example/bloombackend/global/config/resolver/CurrentUserResolver.java
+++ b/src/main/java/com/example/bloombackend/global/config/resolver/CurrentUserResolver.java
@@ -11,10 +11,10 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
 public class CurrentUserResolver implements HandlerMethodArgumentResolver {
-    private final JwtTokenProvider tokenProvider;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public CurrentUserResolver(JwtTokenProvider tokenProvider) {
-        this.tokenProvider = tokenProvider;
+    public CurrentUserResolver(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @Override
@@ -27,6 +27,6 @@ public class CurrentUserResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         String accessToken = webRequest.getHeader("Authorization");
-        return tokenProvider.getUserIdFromToken(accessToken);
+        return jwtTokenProvider.getUserIdFromToken(accessToken);
     }
 }

--- a/src/main/java/com/example/bloombackend/global/config/resolver/CurrentUserResolver.java
+++ b/src/main/java/com/example/bloombackend/global/config/resolver/CurrentUserResolver.java
@@ -1,0 +1,39 @@
+package com.example.bloombackend.global.config.resolver;
+
+import com.example.bloombackend.global.config.JwtTokenProvider;
+import com.example.bloombackend.global.config.annotation.CurrentUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserResolver implements HandlerMethodArgumentResolver {
+    private final JwtTokenProvider tokenProvider;
+
+    public CurrentUserResolver(JwtTokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().isAssignableFrom(Long.class)
+                && parameter.hasParameterAnnotation(CurrentUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String accessToken = getAccessTokenFrom(webRequest.getHeader("Authorization"));
+        return tokenProvider.getUserIdFromToken(accessToken);
+    }
+
+    private String getAccessTokenFrom(String header) {
+        if (header != null && header.startsWith("Authentication ")) {
+            return header.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/bloombackend/global/config/resolver/CurrentUserResolver.java
+++ b/src/main/java/com/example/bloombackend/global/config/resolver/CurrentUserResolver.java
@@ -26,14 +26,7 @@ public class CurrentUserResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        String accessToken = getAccessTokenFrom(webRequest.getHeader("Authorization"));
+        String accessToken = webRequest.getHeader("Authorization");
         return tokenProvider.getUserIdFromToken(accessToken);
-    }
-
-    private String getAccessTokenFrom(String header) {
-        if (header != null && header.startsWith("Authentication ")) {
-            return header.substring(7);
-        }
-        return null;
     }
 }

--- a/src/main/java/com/example/bloombackend/oauth/controller/OAuthController.java
+++ b/src/main/java/com/example/bloombackend/oauth/controller/OAuthController.java
@@ -1,5 +1,6 @@
 package com.example.bloombackend.oauth.controller;
 
+import com.example.bloombackend.oauth.controller.dto.response.LoginResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +24,7 @@ public class OAuthController {
 	}
 
 	@PostMapping("/kakao")
-	public ResponseEntity<String> loginKakao(@RequestBody KakaoLoginRequest request) {
+	public ResponseEntity<LoginResponse> loginKakao(@RequestBody KakaoLoginRequest request) {
 		return ResponseEntity.ok(oAuthLoginService.login(request.authorizationCode()));
 	}
 

--- a/src/main/java/com/example/bloombackend/oauth/controller/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/bloombackend/oauth/controller/dto/response/LoginResponse.java
@@ -1,0 +1,4 @@
+package com.example.bloombackend.oauth.controller.dto.response;
+
+public record LoginResponse(String accessToken) {
+}

--- a/src/main/java/com/example/bloombackend/oauth/service/OAuthLoginService.java
+++ b/src/main/java/com/example/bloombackend/oauth/service/OAuthLoginService.java
@@ -1,5 +1,6 @@
 package com.example.bloombackend.oauth.service;
 
+import com.example.bloombackend.global.config.JwtTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -10,17 +11,19 @@ import com.example.bloombackend.user.service.UserService;
 public class OAuthLoginService {
 	private final RequestKakaoInfoService requestKakaoInfoService;
 	private final UserService userService;
+	private final JwtTokenProvider jwtTokenProvider;
 
 	@Autowired
-	private OAuthLoginService(RequestKakaoInfoService requestKakaoInfoService, UserService userService) {
+	private OAuthLoginService(RequestKakaoInfoService requestKakaoInfoService, UserService userService, JwtTokenProvider jwtTokenProvider) {
 		this.requestKakaoInfoService = requestKakaoInfoService;
 		this.userService = userService;
+		this.jwtTokenProvider = jwtTokenProvider;
 	}
 
 	public String login(String authorizationCode) {
 		KakaoInfoResponse response = requestKakaoInfoService.request(authorizationCode);
 		Long userId = userService.findOrCreateUser(response);
-		return "genertaed-token";
+		return jwtTokenProvider.createAccessToken(userId.toString());
 	}
 
 	public String getKakaoLoginUrl() {

--- a/src/main/java/com/example/bloombackend/oauth/service/OAuthLoginService.java
+++ b/src/main/java/com/example/bloombackend/oauth/service/OAuthLoginService.java
@@ -1,6 +1,7 @@
 package com.example.bloombackend.oauth.service;
 
 import com.example.bloombackend.global.config.JwtTokenProvider;
+import com.example.bloombackend.oauth.controller.dto.response.LoginResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,10 +21,11 @@ public class OAuthLoginService {
 		this.jwtTokenProvider = jwtTokenProvider;
 	}
 
-	public String login(String authorizationCode) {
+	public LoginResponse login(String authorizationCode) {
 		KakaoInfoResponse response = requestKakaoInfoService.request(authorizationCode);
 		Long userId = userService.findOrCreateUser(response);
-		return jwtTokenProvider.createAccessToken(userId.toString());
+		String accessToken = jwtTokenProvider.createAccessToken(userId.toString());
+		return new LoginResponse(accessToken);
 	}
 
 	public String getKakaoLoginUrl() {


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #6

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
### 1. 커스텀 어노테이션 추가
간단히 `@CurrentUser` 어노테이션만 컨트롤러 파라미터에 써두면 현재 유저 ID를 Access 토큰으로 부터 추출해서 가져오도록 했어요

MVC 구조상에서 컨트롤러 바로 앞단 Resolver 영역에서 커스텀 어노테이션을 만들어 구현하였습니다!
이렇게 하면 컨트롤러 이후의 코드 상에서도 어노테이션 이외에 인가 관련해서 의존될 부분이 없으니 단순한 구조로 개발이 가능해서 좋더라구요.

현재는 토큰내에 유저 ID만 담아두었지만, 필요한 정보가 있다면(이메일, 닉네임 등) 언제든 수정 가능해요

⬇️ 간단히 테스트 해보면
    ![image](https://github.com/user-attachments/assets/59932a06-787b-450b-be31-13a409e41a6e)
⬇️ 해당 유저 아이디를 받아와지는 것 확인가능해요
    <img width="461" alt="image" src="https://github.com/user-attachments/assets/accd3cfa-27dc-455e-be53-acd2d5f307b0">
### 2. 인가가 필요한 요청시 accessToken 사용법
⬇️ 아래처럼 accessToken이 로그인 시 응답으로 제공되도록 수정했어요
<img width="860" alt="image" src="https://github.com/user-attachments/assets/09d20d45-faf2-447c-832b-4d7ccf544ff8">
⬇️ 이후 `@CurrentUser`를 사용해야하는 요청에는 Authorization 헤더에 토큰을 넣어주면 됩니다!
<img width="740" alt="image" src="https://github.com/user-attachments/assets/647d1961-0069-488a-95e0-b6cc7ca4ea78">


## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
현재는 AccessToken만 만들어진 상태인데, 토큰을 연장하고 로그아웃을 구현하려면 refresh 토큰이 필요한 상태에요. 다만 이를 구현하려면 프론트에서 토큰의 만료된 시기를 알아야하는데 기본적인 error, status 등의 응답 구조가 완성이 되어야 연동이 가능해질 것 같아요.

기본적인 인가는 가능하니, 우선 기능 개발에 사용하시고 이슈로 만들어서 추가로 개발하도록 할게요!
