### PR TITLE
보낸메시지가 조회되지 않는 이슈 해결

### DIFF
--- a/src/main/java/com/example/bloombackend/bottlemsg/repository/BottleMessageReactionRepository.java
+++ b/src/main/java/com/example/bloombackend/bottlemsg/repository/BottleMessageReactionRepository.java
@@ -11,7 +11,7 @@ import com.example.bloombackend.user.entity.UserEntity;
 
 public interface BottleMessageReactionRepository
 	extends JpaRepository<BottleMessageReaction, Long>, BottleMessageReactionRepositoryCustom {
-	Optional<BottleMessageReaction> findByReactorId(Long UserId);
+	Optional<BottleMessageReaction> findByReactor(UserEntity reactor);
 
 	Void deleteByMessageIdAndReactorAndReactionType(Long messageId, UserEntity reactor, ReactionType reactionType);
 }

--- a/src/main/java/com/example/bloombackend/bottlemsg/repository/BottleMessageRepository.java
+++ b/src/main/java/com/example/bloombackend/bottlemsg/repository/BottleMessageRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.bloombackend.bottlemsg.entity.BottleMessageEntity;
 import com.example.bloombackend.bottlemsg.repository.querydsl.BottleMessageRepositoryCustom;
+import com.example.bloombackend.user.entity.UserEntity;
 
 public interface BottleMessageRepository
 	extends JpaRepository<BottleMessageEntity, Long>, BottleMessageRepositoryCustom {
-	List<BottleMessageEntity> findBySenderId(Long userId);
+	List<BottleMessageEntity> findBySender(UserEntity sender);
 }

--- a/src/main/java/com/example/bloombackend/bottlemsg/sevice/BottleMessageService.java
+++ b/src/main/java/com/example/bloombackend/bottlemsg/sevice/BottleMessageService.java
@@ -66,7 +66,7 @@ public class BottleMessageService {
 	}
 
 	private boolean isReacted(Long userId) {
-		return bottleMessageReactionRepository.findByReactorId(userId).isPresent();
+		return bottleMessageReactionRepository.findByReactor(userService.findUserById(userId)).isPresent();
 	}
 
 	private void createBottleMessageReceiptLog(Long userId, BottleMessageEntity message) {
@@ -147,7 +147,7 @@ public class BottleMessageService {
 
 	@Transactional(readOnly = true)
 	public UserBottleMessagesResponse getSentBottleMessages(Long userId) {
-		List<BottleMessageEntity> sentMessages = bottleMessageRepository.findBySenderId(userId);
+		List<BottleMessageEntity> sentMessages = bottleMessageRepository.findBySender(userService.findUserById(userId));
 		return getBottleMessages(sentMessages, userId);
 	}
 


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #33 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- repository 쿼리 메소드 수정

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 궁금한 점인데 혹시 유리병 메시지 컬럼에서 보낸사람(Sender), Reactor(반응을 남긴사람) 등등 유저엔티티와 연관관계를 많이 갖고 있는데 유리병 메시지로 유저의 정보를 조회하거나 하는 경우가 많지 않습니다. 현재는 유저 id로 유저를 검색한뒤 해당 유저 엔티티로 유리병 메시지 관련 엔티티 조회를 하고 있는데 연관관계(@ManyToOne)으로 갖지않고 보낸유저의 Id만 컬럼으로 갖고 있고 있는게 좋지 않나 하는 생각이 듭니다 ! 이렇게 될 경우 발생할 이슈가 있을까요 ?
