### PR TITLE
레디스를 통해 AI 응답을 하루에 한번만 사용할 수 있도록 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 
     //JSONObject
     implementation 'org.json:json:20230227'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 def querydslDir = "build/generated/querydsl"

--- a/src/main/java/com/example/bloombackend/global/AIUtil.java
+++ b/src/main/java/com/example/bloombackend/global/AIUtil.java
@@ -31,7 +31,7 @@ public class AIUtil {
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         Map<String, Object> requestBody = Map.of(
-            "model", "claude-3-sonnet-20240229",
+            "model", "claude-3-5-haiku-20241022",
             "max_tokens", 300,
             "messages", List.of(Map.of(
                 "role", "user",

--- a/src/main/java/com/example/bloombackend/global/config/RedisConfig.java
+++ b/src/main/java/com/example/bloombackend/global/config/RedisConfig.java
@@ -1,0 +1,16 @@
+package com.example.bloombackend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        return template;
+    }
+}


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #61

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- [레디스를 통해 AI 응답을 하루에 한번만 사용할 수 있도록 설정](https://github.com/k-hackathon-bloom/bloom-backend/commit/9fd9c344209a852fe73634fd5c4f379616781176)
- [클로드 모델 변경 sonnet 3.5 -> haiku 3.5](https://github.com/k-hackathon-bloom/bloom-backend/commit/b73292fdefa71b2a49dcc353cf6452d707711e33)

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 시간이 나서 레디스를 적용해보았는데, 로컬에서 사용시 도커를 통해 직접 열어주어야합니당
