### PR TITLE
Fix FCM notification payload

### DIFF
--- a/src/main/java/com/example/bloombackend/global/FcmUtil.java
+++ b/src/main/java/com/example/bloombackend/global/FcmUtil.java
@@ -35,7 +35,7 @@ public class FcmUtil {
 
         String payload = "{"
                 + "\"message\":{"
-                + "\"fcmToken\":\"" + targetToken + "\","
+                + "\"token\":\"" + targetToken + "\","
                 + "\"notification\":{"
                 + "\"title\":\"" + title + "\","
                 + "\"body\":\"" + body + "\""


### PR DESCRIPTION
## Summary
- fix typo in FCM payload key when sending notification

## Testing
- `gradle test` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_684509ec0c988331a5ad1b0c772d97a4