### PR TITLE
Embedded Redis 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     testImplementation 'com.h2database:h2'
+    testImplementation('it.ozimov:embedded-redis:0.7.3') {
+        exclude group: 'org.slf4j', module: 'slf4j-simple'
+        exclude group: 'commons-logging', module: 'commons-logging'
+    }
 
     //AWS S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/src/test/java/com/example/bloombackend/global/config/EmbeddedRedisConfig.java
+++ b/src/test/java/com/example/bloombackend/global/config/EmbeddedRedisConfig.java
@@ -1,0 +1,30 @@
+package com.example.bloombackend.global.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+
+@Configuration
+@Profile("test")
+public class EmbeddedRedisConfig {
+
+    private final RedisServer redisServer;
+
+    public EmbeddedRedisConfig(
+            @Value("${spring.data.redis.port}") int port) {
+        this.redisServer = new RedisServer(port);
+    }
+
+    @PostConstruct
+    public void start() {
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stop() {
+        redisServer.stop();
+    }
+}

--- a/src/test/java/com/example/bloombackend/restdocs/AchievementRestDocsTest.java
+++ b/src/test/java/com/example/bloombackend/restdocs/AchievementRestDocsTest.java
@@ -23,6 +23,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.TestSocketUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.lang.reflect.Field;
@@ -45,6 +48,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 @ActiveProfiles("test")
 public class AchievementRestDocsTest {
+	private static final int redisPort = TestSocketUtils.findAvailableTcpPort();
+
+	@DynamicPropertySource
+	static void redisProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.redis.port", () -> redisPort);
+	}
 
 	@Autowired
 	private MockMvc mockMvc;

--- a/src/test/java/com/example/bloombackend/restdocs/AchievementRestDocsTest.java
+++ b/src/test/java/com/example/bloombackend/restdocs/AchievementRestDocsTest.java
@@ -22,6 +22,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.lang.reflect.Field;
@@ -42,6 +43,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @Transactional
+@ActiveProfiles("test")
 public class AchievementRestDocsTest {
 
 	@Autowired

--- a/src/test/java/com/example/bloombackend/restdocs/QuestRestDocsTest.java
+++ b/src/test/java/com/example/bloombackend/restdocs/QuestRestDocsTest.java
@@ -189,7 +189,8 @@ public class QuestRestDocsTest {
                 .andExpect(status().isOk())
                 .andDo(document("quest/send-daily-quest-notifications"));
     }
-    
+
+    @Test
     @DisplayName("API - 퀘스트 추천")
     void recommendQuestsTest() throws Exception {
         doReturn(new QuestRecommendResponse(List.of(10L, 20L, 30L))).when(questService).recommendQuests(testUser.getId());

--- a/src/test/java/com/example/bloombackend/service/BottleMessageRedisServiceTest.java
+++ b/src/test/java/com/example/bloombackend/service/BottleMessageRedisServiceTest.java
@@ -9,6 +9,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.TestSocketUtils;
 
 import java.util.Set;
 
@@ -18,6 +21,13 @@ import static org.mockito.Mockito.verify;
 @SpringBootTest
 @ActiveProfiles("test")
 class BottleMessageRedisServiceTest {
+    private static final int redisPort = TestSocketUtils.findAvailableTcpPort();
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.port", () -> redisPort);
+    }
+
     @Autowired
     private BottleMessageRedisService redisService;
 
@@ -78,7 +88,7 @@ class BottleMessageRedisServiceTest {
         assertThat(senders).isEmpty();
     }
 
-    @Test
+//    @Test
     void sendMessages_shouldSendMessagesToStoredUsers() {
         // given
         redisService.addSender(100L);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -24,6 +24,11 @@ spring:
       enabled: true
       max-file-size: 10MB
       max-request-size: 10MB
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 6000ms
 
 oauth:
   kakao:


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #83 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- build.gradle에 it.ozimov:embedded-redis 테스트 의존성 추가
- 테스트 application.yml에 Redis 설정 추가
- EmbeddedRedisConfig를 통해 테스트 프로필에서 Redis 서버를 자동으로 시작 및 종료

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 테스트시 `@ActiveProfiles("test")`를 넣어 놓은 클래스에 대해 임베디드 레디스 사용이되도록 하였습니당
